### PR TITLE
Support ignoreNodeTypes per rule

### DIFF
--- a/src/textlint-filter-rule-node-types.js
+++ b/src/textlint-filter-rule-node-types.js
@@ -7,17 +7,32 @@ const defaultOptions = {
      */
     nodeTypes: []
 };
+const message = `You forgot setting to options like { "nodeTypes" : ["Str", { "ruleId": "no-todo", "types": ["BlockQuote"] }] }`;
 module.exports = function (context, options = defaultOptions) {
     const {shouldIgnore} = context;
     const nodeTypes = options.nodeTypes || defaultOptions.nodeTypes;
-    assert(Array.isArray(nodeTypes) && nodeTypes.length > 0, `You forgot setting to options like { "nodeTypes" : ["Str"] }`);
+    assert(Array.isArray(nodeTypes) && nodeTypes.length > 0, message);
     const rule = {};
-    nodeTypes.forEach(type => {
-        rule[type] = (node) => {
-            shouldIgnore(node.range, {
-                ruleId: "*"
-            });
+    nodeTypes.forEach(typeEntry => {
+        let types, ruleId;
+        if (typeof typeEntry === "string") {
+            types = [typeEntry];
+            ruleId = "*";
+        } else if (typeof typeEntry === "object") {
+            types = typeEntry.types;
+            ruleId = typeEntry.ruleId;
+            assert(Array.isArray(types) && types.length > 0, message);
+            assert(typeof ruleId === "string", message);
+        } else {
+            assert.fail(message);
         }
+        types.forEach(type => {
+            rule[type] = (node) => {
+                shouldIgnore(node.range, {
+                    ruleId
+                });
+            };
+        });
     });
     return rule;
 };

--- a/test/textlint-filter-rule-node-types-test.js
+++ b/test/textlint-filter-rule-node-types-test.js
@@ -76,4 +76,36 @@ describe("textlint-filter-rule-node-types", function () {
             });
         });
     });
+    context("when report multiple nodes and ignore type with complex nodeTypes", function () {
+        it("should messages is only one message", function () {
+            const textlint = new TextLintCore();
+            textlint.setupRules({
+                report1: reportRule,
+                report2: reportRule
+            }, {
+                report1: {
+                    nodeTypes: [TextLintNodeType.Str]
+                },
+                report2: {
+                    nodeTypes: [TextLintNodeType.Str]
+                }
+            });
+            textlint.setupFilterRules({
+                ignore: filterRule
+            }, {
+                ignore: {
+                    nodeTypes: [
+                        {
+                            ruleId: "report2",
+                            types: [TextLintNodeType.Str]
+                        }
+                    ]
+                }
+            });
+            return textlint.lintText("text").then(({messages}) => {
+                assert.equal(messages.length, 1);
+                assert.equal(messages[0].ruleId, "report1");
+            });
+        });
+    });
 });


### PR DESCRIPTION
This PR supports ignore nodeTypes per rule.

With this change, the array of nodeTypes option will accept `{ "ruleId": "no-todo", "types": ["BlockQuote"] }` for object.

close #10.